### PR TITLE
docs: add Baton task coordination guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+**CodeFlow Engine** — Core AutoPR engine and consolidated monorepo for the CodeFlow ecosystem. AI-powered code quality and PR automation.
+
+## Tech Stack
+
+- **Engine**: Python (`codeflow_engine/`)
+- **Desktop**: Tauri + React + TypeScript (`desktop/`)
+- **Website**: Next.js (`website/`)
+- **Orchestration**: Scripts and docs (`orchestration/`)
+- **Type Checking**: mypy (`mypy.ini`)
+- **Coverage**: Codecov (`codecov.yml`)
+
+## Key Commands
+
+```bash
+# Python engine
+cd engine && pip install -e .
+pytest                    # Run tests
+mypy .                    # Type check
+coverage run -m pytest    # Coverage
+
+# Desktop app
+cd desktop && npm install && npm run dev
+
+# Website
+cd website && npm install && npm run dev
+```
+
+## Architecture (Monorepo Layout)
+
+- `engine/` — Core Python AutoPR engine
+- `codeflow_engine/` — Python package source
+- `desktop/` — Tauri + React desktop application
+- `website/` — Next.js marketing and documentation site
+- `orchestration/` — Shared infrastructure, bootstrap assets, release orchestration
+
+## Migration History
+
+This monorepo was created Dec 2025 by consolidating separate repos (`codeflow-desktop`, `codeflow-website`, `codeflow-orchestration`) with preserved git history. See `MIGRATION_GUIDE.md` and `MIGRATION_PLAN.md`.
+
+## AgentKit Forge
+
+This project has not yet been onboarded to [AgentKit Forge](https://github.com/phoenixvc/agentkit-forge). To request onboarding, [create a ticket](https://github.com/phoenixvc/agentkit-forge/issues/new?title=Onboard+codeflow-engine&labels=onboarding).
+
+## Baton Integration
+
+Baton is the shared task graph for cross-repo work. When the `baton` MCP server is available, agents should check for existing work with `task_check` at the start of meaningful tasks, create or claim visible work with `task_notify`/`log_agent_message`, update the task when significant new information becomes available, and log completion or blockers before handing off.


### PR DESCRIPTION
Adds concise Baton MCP coordination guidance to CLAUDE.md: check task_check at meaningful task start, create or claim visible work with task_notify/log_agent_message, update tasks as significant information arrives, and log completion or blockers before handoff.